### PR TITLE
Update to take Fedora in account

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,14 +4,17 @@ galaxy_info:
   description: Ansible module to enforce SELinux policies
   company: Red Hat
   license: MIT
-  min_ansible_version: 1.2
-  # Only tested with EL 7. No reason anything do
-  # not work anywhere else, just no time to test.
-  # I would welcome patches
+  min_ansible_version: 2.0
   platforms:
   - name: EL
     versions:
     - 7
+    - 6
+  - name: Fedora
+    versions:
+    - 24
+    - 25
+    - 26
   categories:
   - system
 dependencies:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,10 +15,8 @@
     pkg: "{{ item }}"
     state: installed
   with_items:
-  # for debugging
-  - setools-console
-  - policycoreutils-python
-  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version >= '6'
+  - policycoreutils-python-utils
+  when: ansible_os_family == 'Fedora'
 
 - name: Set state to enforcing
   command: setenforce 1


### PR DESCRIPTION
Also drop EL5, since Centos 5 is EOL, and
update the metadata.